### PR TITLE
Use v1 of setup-dotnet (Should fix CI issue)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1.7.2
+        uses: actions/setup-dotnet@v1
       - name: Install dependencies
         run: dotnet restore
       - name: Build


### PR DESCRIPTION
I don't know what's the issue with later versions, but this version is what seems to be working with me.

Also, thanks a lot @jmarolf! I've always wanted some neat infrastructure for .NET! ❤️ 